### PR TITLE
Demo section showing dark fonts

### DIFF
--- a/src/components/TryItOut/styles.module.css
+++ b/src/components/TryItOut/styles.module.css
@@ -10,7 +10,7 @@
 }
 
 .secondaryBtn {
-  color: var(--muted-on-surface);
+  color: var(--white) !important;
 }
 
 .contentFooter {
@@ -44,20 +44,20 @@
 }
 
 .text {
-  color: var(--muted-more-foreground);
+  color: var(--gray-400);
 }
 
 .indicator {
-  color: var(--segment-button-foreground);
+  color: var(--gray-400);
 }
 
 .accordionTrigger {
-  color: var(--muted-more-foreground);
+  color: var(--gray-400);
   padding: var(--space-4x) 0;
   border: none;
   outline: none;
   & p {
-    color: var(--muted-more-foreground);
+    color: var(--gray-400);
   }
 
   & svg {
@@ -81,7 +81,7 @@
   border-top: 2px solid var(--link);
 
   & .accordionTrigger {
-    color: var(--background);
+    color: var(--white);
   }
   & .indicator {
     color: var(--link);


### PR DESCRIPTION
## Summary
The design system has `darkMode: ['class']` which means dark mode is controlled by a class. The issue is that `--background` and `--foreground` swap values in dark mode.

- [x] Changed text colors to use the direct property (e.g `var(--white)`)