### PR TITLE
fix: remove clickable functionality from network names in token drawer

### DIFF
--- a/src/components/CCIP/Drawer/TokenDrawer.tsx
+++ b/src/components/CCIP/Drawer/TokenDrawer.tsx
@@ -341,29 +341,8 @@ function TokenDrawer({
                     return (
                       <tr key={networkDetails.name} className={tokenPaused ? "ccip-table__row--paused" : ""}>
                         <td>
-                          <button
-                            type="button"
+                          <div
                             className={`ccip-table__network-name ${tokenPaused ? "ccip-table__network-name--paused" : ""}`}
-                            onClick={() => {
-                              drawerWidthStore.set(DrawerWidth.Wide)
-                              drawerContentStore.set(() => (
-                                <LaneDrawer
-                                  environment={environment}
-                                  lane={laneData}
-                                  sourceNetwork={network}
-                                  destinationNetwork={{
-                                    name: networkDetails?.name || "",
-                                    logo: networkDetails?.logo || "",
-                                    key: destinationChain,
-                                  }}
-                                  inOutbound={
-                                    activeTab === TokenTab.Outbound ? LaneFilter.Outbound : LaneFilter.Inbound
-                                  }
-                                  explorer={network.explorer}
-                                />
-                              ))
-                            }}
-                            aria-label={`View lane details for ${networkDetails?.name}`}
                           >
                             <img
                               src={networkDetails?.logo}
@@ -376,7 +355,7 @@ function TokenDrawer({
                                 ⏸️
                               </span>
                             )}
-                          </button>
+                          </div>
                         </td>
                         <td>
                           <RateLimitCell

--- a/src/components/CCIP/Tables/Table.css
+++ b/src/components/CCIP/Tables/Table.css
@@ -47,7 +47,6 @@
   color: #000;
   display: flex;
   align-items: center;
-  cursor: pointer;
   border: none;
   background: none;
   width: 100%;


### PR DESCRIPTION
- Convert button element to div in TokenDrawer.tsx to remove click functionality
- Remove cursor pointer style from ccip-table__network-name CSS class
- Maintains visual styling while preventing unintended navigation
- Part of token drawer navigation improvements

