### PR TITLE
Add sublabels to rate limit columns and fix table styling issues

### DIFF
--- a/src/components/CCIP/Chain/ChainTokenGrid.tsx
+++ b/src/components/CCIP/Chain/ChainTokenGrid.tsx
@@ -1,7 +1,7 @@
 import { Environment, Version, Network, PoolType } from "~/config/data/ccip/types.ts"
 import { getAllTokenLanes, getTokenData } from "~/config/data/ccip/data.ts"
 import TokenCard from "../Cards/TokenCard.tsx"
-import { drawerContentStore } from "../Drawer/drawerStore.ts"
+import { drawerContentStore, DrawerWidth, drawerWidthStore } from "../Drawer/drawerStore.ts"
 import TokenDrawer from "../Drawer/TokenDrawer.tsx"
 import { directoryToSupportedChain, getChainIcon, getChainTypeAndFamily, getTitle } from "~/features/utils/index.ts"
 import { useState } from "react"
@@ -69,6 +69,7 @@ function ChainTokenGrid({ tokens, network, environment }: ChainTokenGridProps) {
                     version: Version.V1_2_0,
                     token: token.id,
                   })[selectedNetwork.key]
+                  drawerWidthStore.set(DrawerWidth.Wide)
                   drawerContentStore.set(() => (
                     <TokenDrawer
                       token={{

--- a/src/components/CCIP/ChainHero/ChainHero.css
+++ b/src/components/CCIP/ChainHero/ChainHero.css
@@ -47,7 +47,7 @@
   --doc-padding: var(--space-6x);
   gap: var(--gutter);
   padding: var(--space-6x);
-  margin: 0;
+  margin: 0 auto;
   display: flex;
   flex-direction: column;
 }
@@ -167,7 +167,13 @@
   .ccip-chain-hero__content {
     --gutter: var(--space-10x);
     grid-template-columns: 1fr 1fr;
+    padding: var(--space-10x) var(--space-8x);
+  }
+
+  /* Drawer-specific styles to match drawer heading width */
+  .ccip-chain-hero--drawer .ccip-chain-hero__content {
     padding: var(--space-10x);
+    margin: 0;
   }
 
   .ccip-chain-hero__fee-tokens-group-item {

--- a/src/components/CCIP/ChainHero/ChainHero.css
+++ b/src/components/CCIP/ChainHero/ChainHero.css
@@ -47,7 +47,7 @@
   --doc-padding: var(--space-6x);
   gap: var(--gutter);
   padding: var(--space-6x);
-  margin: 0 auto;
+  margin: 0;
   display: flex;
   flex-direction: column;
 }
@@ -167,7 +167,7 @@
   .ccip-chain-hero__content {
     --gutter: var(--space-10x);
     grid-template-columns: 1fr 1fr;
-    padding: var(--space-10x) var(--space-8x);
+    padding: var(--space-10x);
   }
 
   .ccip-chain-hero__fee-tokens-group-item {

--- a/src/components/CCIP/ChainHero/LaneDetailsHero.css
+++ b/src/components/CCIP/ChainHero/LaneDetailsHero.css
@@ -65,6 +65,11 @@
 
 @media screen and (min-width: 768px) {
   .lane-details-hero {
+    padding: var(--space-6x) var(--space-8x) var(--space-10x);
+  }
+
+  /* Drawer-specific styles to match drawer heading width */
+  .lane-details-hero--drawer {
     padding: var(--space-6x) var(--space-10x) var(--space-10x);
   }
 

--- a/src/components/CCIP/ChainHero/LaneDetailsHero.tsx
+++ b/src/components/CCIP/ChainHero/LaneDetailsHero.tsx
@@ -23,6 +23,7 @@ interface LaneDetailsHeroProps {
   destinationAddress: string
   explorer: ExplorerInfo
   inOutbound: LaneFilter
+  inDrawer?: boolean
 }
 
 // Arrow component to avoid duplication
@@ -87,9 +88,10 @@ function LaneDetailsHero({
   destinationAddress,
   explorer,
   inOutbound,
+  inDrawer = false,
 }: LaneDetailsHeroProps) {
   return (
-    <div className="lane-details-hero">
+    <div className={`lane-details-hero ${inDrawer ? "lane-details-hero--drawer" : ""}`}>
       {/* Display networks with direction based on lane type */}
       <div className="lane-details-hero__networks">
         {inOutbound === LaneFilter.Inbound ? (

--- a/src/components/CCIP/ChainHero/TokenDetailsHero.tsx
+++ b/src/components/CCIP/ChainHero/TokenDetailsHero.tsx
@@ -23,11 +23,12 @@ interface TokenDetailsHeroProps {
     poolType: PoolType
     poolAddress: string
   }
+  inDrawer?: boolean
 }
 
-function TokenDetailsHero({ network, token }: TokenDetailsHeroProps) {
+function TokenDetailsHero({ network, token, inDrawer = false }: TokenDetailsHeroProps) {
   return (
-    <section className="ccip-chain-hero">
+    <section className={`ccip-chain-hero ${inDrawer ? "ccip-chain-hero--drawer" : ""}`}>
       <div className="ccip-chain-hero__content">
         <div className="ccip-chain-hero__heading">
           <div className="ccip-chain-hero__heading__images">

--- a/src/components/CCIP/Drawer/LaneDrawer.tsx
+++ b/src/components/CCIP/Drawer/LaneDrawer.tsx
@@ -76,6 +76,7 @@ function LaneDrawer({
         sourceAddress={sourceNetworkDetails?.chainSelector || ""}
         destinationAddress={destinationNetworkDetails?.chainSelector || ""}
         inOutbound={inOutbound}
+        inDrawer={true}
       />
 
       <div className="ccip-table__drawer-container">

--- a/src/components/CCIP/Drawer/LaneDrawer.tsx
+++ b/src/components/CCIP/Drawer/LaneDrawer.tsx
@@ -79,7 +79,7 @@ function LaneDrawer({
         inDrawer={true}
       />
 
-      <div className="ccip-table__drawer-container">
+      <div className="ccip-table__drawer-container ccip-table__drawer-container--lane">
         <div className="ccip-table__filters">
           <div>
             <div className="ccip-table__filters-title">
@@ -126,9 +126,7 @@ function LaneDrawer({
                       }}
                     />
                   </div>
-                  <div style={{ color: "var(--muted-more-foreground)", fontSize: "0.875rem", fontWeight: "normal" }}>
-                    (Tokens)
-                  </div>
+                  <span className="ccip-table__header-sublabel">(Tokens)</span>
                 </th>
                 <th style={{ width: "180px" }}>
                   <div>
@@ -146,9 +144,7 @@ function LaneDrawer({
                       }}
                     />
                   </div>
-                  <div style={{ color: "var(--muted-more-foreground)", fontSize: "0.875rem", fontWeight: "normal" }}>
-                    (Tokens/sec)
-                  </div>
+                  <span className="ccip-table__header-sublabel">(Tokens/sec)</span>
                 </th>
                 <th style={{ width: "150px" }}>
                   <div>
@@ -166,9 +162,7 @@ function LaneDrawer({
                       }}
                     />
                   </div>
-                  <div style={{ color: "var(--muted-more-foreground)", fontSize: "0.875rem", fontWeight: "normal" }}>
-                    (Tokens)
-                  </div>
+                  <span className="ccip-table__header-sublabel">(Tokens)</span>
                 </th>
                 <th style={{ width: "180px" }}>
                   <div>
@@ -186,9 +180,7 @@ function LaneDrawer({
                       }}
                     />
                   </div>
-                  <div style={{ color: "var(--muted-more-foreground)", fontSize: "0.875rem", fontWeight: "normal" }}>
-                    (Tokens/sec)
-                  </div>
+                  <span className="ccip-table__header-sublabel">(Tokens/sec)</span>
                 </th>
               </tr>
             </thead>

--- a/src/components/CCIP/Drawer/TokenDrawer.tsx
+++ b/src/components/CCIP/Drawer/TokenDrawer.tsx
@@ -211,7 +211,7 @@ function TokenDrawer({
             <table className="ccip-table">
               <thead>
                 <tr>
-                  <th>
+                  <th className="ccip-table__verifier-name-header">
                     <Typography variant="body-semi-s">Verifier name</Typography>
                   </th>
                   <th>
@@ -287,37 +287,49 @@ function TokenDrawer({
                     />
                   </th>
                   <th>
-                    Rate limit capacity
-                    <Tooltip
-                      label=""
-                      tip="Maximum amount per transaction"
-                      labelStyle={{
-                        marginRight: "5px",
-                      }}
-                      style={{
-                        display: "inline-block",
-                        verticalAlign: "middle",
-                        marginBottom: "2px",
-                      }}
-                    />
+                    <div>
+                      Rate limit capacity
+                      <Tooltip
+                        label=""
+                        tip="Maximum amount per transaction"
+                        labelStyle={{
+                          marginRight: "5px",
+                        }}
+                        style={{
+                          display: "inline-block",
+                          verticalAlign: "middle",
+                          marginBottom: "2px",
+                        }}
+                      />
+                    </div>
+                    <span className="ccip-table__header-sublabel">(Tokens)</span>
                   </th>
                   <th>
-                    Rate limit refill rate
-                    <Tooltip
-                      label=""
-                      tip="Rate at which available capacity is replenished"
-                      labelStyle={{
-                        marginRight: "5px",
-                      }}
-                      style={{
-                        display: "inline-block",
-                        verticalAlign: "middle",
-                        marginBottom: "2px",
-                      }}
-                    />
+                    <div>
+                      Rate limit refill rate
+                      <Tooltip
+                        label=""
+                        tip="Rate at which available capacity is replenished"
+                        labelStyle={{
+                          marginRight: "5px",
+                        }}
+                        style={{
+                          display: "inline-block",
+                          verticalAlign: "middle",
+                          marginBottom: "2px",
+                        }}
+                      />
+                    </div>
+                    <span className="ccip-table__header-sublabel">(Tokens/sec)</span>
                   </th>
-                  <th>FTF Rate limit capacity</th>
-                  <th>FTF Rate limit refill rate</th>
+                  <th>
+                    <div>FTF Rate limit capacity</div>
+                    <span className="ccip-table__header-sublabel">(Tokens)</span>
+                  </th>
+                  <th>
+                    <div>FTF Rate limit refill rate</div>
+                    <span className="ccip-table__header-sublabel">(Tokens/sec)</span>
+                  </th>
                   <th>Verifiers</th>
                 </tr>
               </thead>

--- a/src/components/CCIP/Drawer/TokenDrawer.tsx
+++ b/src/components/CCIP/Drawer/TokenDrawer.tsx
@@ -182,6 +182,7 @@ function TokenDrawer({
           explorer: network.explorer,
           chainType: network.chainType,
         }}
+        inDrawer={true}
       />
       <div className="ccip-table__drawer-container">
         <div className="ccip-table__filters">

--- a/src/components/CCIP/Drawer/TokenDrawer.tsx
+++ b/src/components/CCIP/Drawer/TokenDrawer.tsx
@@ -184,7 +184,7 @@ function TokenDrawer({
         }}
         inDrawer={true}
       />
-      <div className="ccip-table__drawer-container">
+      <div className="ccip-table__drawer-container ccip-table__drawer-container--token">
         <div className="ccip-table__filters">
           <div>
             <Tabs

--- a/src/components/CCIP/Tables/Table.css
+++ b/src/components/CCIP/Tables/Table.css
@@ -44,7 +44,7 @@
 .ccip-table__drawer-container .ccip-table thead th:nth-child(7) {
   /* Verifiers */
   width: 10%;
-  text-align: center !important;
+  text-align: right !important;
 }
 
 .ccip-table tbody tr:first-child {

--- a/src/components/CCIP/Tables/Table.css
+++ b/src/components/CCIP/Tables/Table.css
@@ -11,40 +11,81 @@
 }
 
 /* Column width specifications for lanes accordion table in drawer only */
-.ccip-table__drawer-container .ccip-table thead th:nth-child(1) {
-  /* Destination/Source network */
+.ccip-table__drawer-container--token .ccip-table thead th:nth-child(1) {
+  /* Destination/Source network in TokenDrawer */
   width: 25%;
 }
 
-.ccip-table__drawer-container .ccip-table thead th:nth-child(2) {
-  /* Mechanism */
+.ccip-table__drawer-container--lane .ccip-table thead th:nth-child(1) {
+  /* Ticker column in LaneDrawer */
+  width: 100px;
+}
+
+.ccip-table__drawer-container--token .ccip-table thead th:nth-child(2) {
+  /* Mechanism in TokenDrawer */
   width: 15%;
 }
 
-.ccip-table__drawer-container .ccip-table thead th:nth-child(3) {
-  /* Rate limit capacity */
+.ccip-table__drawer-container--token .ccip-table thead th:nth-child(3) {
+  /* Rate limit capacity in TokenDrawer */
   width: 15%;
 }
 
-.ccip-table__drawer-container .ccip-table thead th:nth-child(4) {
-  /* Rate limit refill rate */
+.ccip-table__drawer-container--token .ccip-table thead th:nth-child(4) {
+  /* Rate limit refill rate in TokenDrawer */
   width: 15%;
 }
 
-.ccip-table__drawer-container .ccip-table thead th:nth-child(5) {
-  /* FTF Rate limit capacity */
+.ccip-table__drawer-container--token .ccip-table thead th:nth-child(5) {
+  /* FTF Rate limit capacity in TokenDrawer */
   width: 15%;
 }
 
-.ccip-table__drawer-container .ccip-table thead th:nth-child(6) {
-  /* FTF Rate limit refill rate */
+.ccip-table__drawer-container--token .ccip-table thead th:nth-child(6) {
+  /* FTF Rate limit refill rate in TokenDrawer */
   width: 15%;
 }
 
-.ccip-table__drawer-container .ccip-table thead th:nth-child(7) {
-  /* Verifiers */
+.ccip-table__drawer-container--lane .ccip-table thead th:nth-child(2) {
+  /* Source token address in LaneDrawer */
+  width: 150px;
+}
+
+.ccip-table__drawer-container--lane .ccip-table thead th:nth-child(3) {
+  /* Decimals in LaneDrawer */
+  width: 80px;
+}
+
+.ccip-table__drawer-container--lane .ccip-table thead th:nth-child(4) {
+  /* Mechanism in LaneDrawer */
+  width: 100px;
+}
+
+.ccip-table__drawer-container--lane .ccip-table thead th:nth-child(5) {
+  /* Rate limit capacity in LaneDrawer */
+  width: 150px;
+}
+
+.ccip-table__drawer-container--lane .ccip-table thead th:nth-child(6) {
+  /* Rate limit refill rate in LaneDrawer */
+  width: 180px;
+}
+
+.ccip-table__drawer-container--lane .ccip-table thead th:nth-child(8) {
+  /* FTF Rate limit refill rate in LaneDrawer (8th column) */
+  width: 180px;
+}
+
+.ccip-table__drawer-container--token .ccip-table thead th:nth-child(7) {
+  /* Verifiers column in TokenDrawer */
   width: 10%;
   text-align: right !important;
+}
+
+.ccip-table__drawer-container--lane .ccip-table thead th:nth-child(7) {
+  /* FTF Rate limit capacity column in LaneDrawer */
+  width: 15%;
+  text-align: left;
 }
 
 .ccip-table tbody tr:first-child {

--- a/src/components/CCIP/Tables/Table.css
+++ b/src/components/CCIP/Tables/Table.css
@@ -10,38 +10,38 @@
   width: 15% !important;
 }
 
-/* Column width specifications for main accordion table only */
-.ccip-table thead th:nth-child(1) {
+/* Column width specifications for lanes accordion table in drawer only */
+.ccip-table__drawer-container .ccip-table thead th:nth-child(1) {
   /* Destination/Source network */
   width: 25%;
 }
 
-.ccip-table thead th:nth-child(2) {
+.ccip-table__drawer-container .ccip-table thead th:nth-child(2) {
   /* Mechanism */
   width: 15%;
 }
 
-.ccip-table thead th:nth-child(3) {
+.ccip-table__drawer-container .ccip-table thead th:nth-child(3) {
   /* Rate limit capacity */
   width: 15%;
 }
 
-.ccip-table thead th:nth-child(4) {
+.ccip-table__drawer-container .ccip-table thead th:nth-child(4) {
   /* Rate limit refill rate */
   width: 15%;
 }
 
-.ccip-table thead th:nth-child(5) {
+.ccip-table__drawer-container .ccip-table thead th:nth-child(5) {
   /* FTF Rate limit capacity */
   width: 15%;
 }
 
-.ccip-table thead th:nth-child(6) {
+.ccip-table__drawer-container .ccip-table thead th:nth-child(6) {
   /* FTF Rate limit refill rate */
   width: 15%;
 }
 
-.ccip-table thead th:nth-child(7) {
+.ccip-table__drawer-container .ccip-table thead th:nth-child(7) {
   /* Verifiers */
   width: 10%;
   text-align: center !important;
@@ -76,10 +76,15 @@
   background-color: transparent;
   color: var(--gray-700);
   align-content: baseline;
+  padding-left: 0;
 }
 
-.ccip-table thead th:first-child {
+.ccip-table__drawer-container .ccip-table thead th:first-child:not(.ccip-table__verifier-name-header) {
   padding-left: var(--space-6x);
+}
+
+.ccip-table__verifier-name-header {
+  padding-left: 0 !important;
 }
 
 .ccip-table tbody td {
@@ -383,8 +388,8 @@
   pointer-events: none;
 }
 
-/* Align verifiers column content to the right - main table only */
-.ccip-table:not(.ccip-table--verifiers) tbody td:nth-child(7) {
+/* Align verifiers column content to the right - drawer lanes table only */
+.ccip-table__drawer-container .ccip-table:not(.ccip-table--verifiers) tbody td:nth-child(7) {
   text-align: right;
 }
 
@@ -467,4 +472,13 @@
 .ccip-table__paused-badge {
   margin-left: var(--space-2x);
   font-size: 12px;
+}
+
+.ccip-table__header-sublabel {
+  font-size: 0.875em;
+  margin-top: var(--space-1x);
+  display: block;
+  color: var(--muted-more-foreground, #9fa7b2);
+  font-weight: 600;
+  line-height: 22px;
 }

--- a/src/components/CCIP/Tables/Table.css
+++ b/src/components/CCIP/Tables/Table.css
@@ -482,3 +482,157 @@
   font-weight: 600;
   line-height: 22px;
 }
+
+/* Mobile responsive styles for Token Drawer tables */
+@media (max-width: 768px) {
+  .ccip-table__drawer-container {
+    padding: var(--space-4x);
+  }
+
+  .ccip-table {
+    font-size: 12px;
+    table-layout: auto;
+  }
+
+  /* Override fixed widths on mobile for drawer tables */
+  .ccip-table__drawer-container .ccip-table thead th {
+    width: auto !important;
+    min-width: 80px;
+    padding: var(--space-2x) var(--space-2x) var(--space-2x) 0;
+    font-size: 12px;
+  }
+
+  .ccip-table__drawer-container .ccip-table thead th:first-child {
+    padding-left: var(--space-3x);
+    min-width: 120px;
+  }
+
+  .ccip-table__drawer-container .ccip-table thead th:nth-child(7) {
+    min-width: 60px;
+  }
+
+  .ccip-table tbody td {
+    padding: var(--space-3x) var(--space-2x) var(--space-3x) 0;
+    font-size: 12px;
+  }
+
+  .ccip-table__accordion-row td {
+    padding-left: var(--space-3x);
+  }
+
+  .ccip-table__accordion-row td:first-child {
+    padding-left: var(--space-3x);
+  }
+
+  .ccip-table__network-name {
+    font-size: 12px;
+  }
+
+  .ccip-table tbody td .ccip-table__logo {
+    width: 20px;
+    height: 20px;
+    margin-right: var(--space-2x);
+  }
+
+  /* Hide sublabels on mobile to save vertical space */
+  .ccip-table__header-sublabel {
+    display: none;
+  }
+
+  /* Make mechanism column more compact */
+  .ccip-table__drawer-container .ccip-table thead th:nth-child(2) {
+    font-size: 11px;
+  }
+
+  /* Reduce verifier content padding */
+  .ccip-table__verifier-content {
+    padding: 0;
+  }
+
+  .ccip-table--verifiers thead th,
+  .ccip-table--verifiers tbody td {
+    padding: var(--space-2x) var(--space-3x);
+    font-size: 11px;
+  }
+
+  .ccip-table--verifiers thead th:first-child,
+  .ccip-table--verifiers tbody td:first-child {
+    padding-left: var(--space-3x);
+  }
+
+  .ccip-table--verifiers .ccip-table__logo {
+    width: 18px;
+    height: 18px;
+  }
+
+  /* Adjust tooltip positioning on mobile */
+  .rate-tooltip-cell {
+    min-width: 80px;
+  }
+
+  /* Make paused badge smaller on mobile */
+  .ccip-table__paused-badge {
+    font-size: 10px;
+    margin-left: var(--space-1x);
+  }
+
+  /* Verifiers tab table mobile styles */
+  .ccip-table__verifier-name-header {
+    min-width: 80px !important;
+    width: auto !important;
+  }
+
+  /* Make all verifier table columns responsive */
+  .ccip-table:not(.ccip-table--verifiers) thead th {
+    white-space: nowrap;
+    font-size: 10px !important;
+    padding: var(--space-2x) var(--space-1x) !important;
+  }
+
+  /* Compact the standalone verifiers table (in Verifiers tab) */
+  .ccip-table__wrapper > .ccip-table {
+    font-size: 11px;
+  }
+
+  .ccip-table__wrapper > .ccip-table thead th {
+    padding: var(--space-2x) var(--space-1x);
+    font-size: 10px;
+    line-height: 1.2;
+    white-space: nowrap;
+  }
+
+  .ccip-table__wrapper > .ccip-table tbody td {
+    padding: var(--space-2x) var(--space-1x);
+    font-size: 10px;
+    vertical-align: middle;
+  }
+
+  .ccip-table__wrapper > .ccip-table tbody td > div {
+    display: flex;
+    align-items: center;
+    gap: var(--space-1x);
+  }
+
+  .ccip-table__wrapper > .ccip-table .ccip-table__logo {
+    width: 16px !important;
+    height: 16px !important;
+    margin-right: 0 !important;
+    flex-shrink: 0;
+  }
+
+  /* Make verifier name column slightly wider */
+  .ccip-table__wrapper > .ccip-table thead th:nth-child(1) {
+    min-width: 90px;
+  }
+
+  /* Compress address column */
+  .ccip-table__wrapper > .ccip-table thead th:nth-child(2) {
+    min-width: 70px;
+  }
+
+  /* Make type and threshold columns narrower */
+  .ccip-table__wrapper > .ccip-table thead th:nth-child(3),
+  .ccip-table__wrapper > .ccip-table thead th:nth-child(4) {
+    min-width: 60px;
+  }
+}

--- a/src/components/CCIP/Tables/TokenChainsTable.tsx
+++ b/src/components/CCIP/Tables/TokenChainsTable.tsx
@@ -1,6 +1,6 @@
 import Address from "~/components/AddressReact.tsx"
 import "./Table.css"
-import { drawerContentStore } from "../Drawer/drawerStore.ts"
+import { drawerContentStore, DrawerWidth, drawerWidthStore } from "../Drawer/drawerStore.ts"
 import { Environment, SupportedTokenConfig, tokenPoolDisplay, PoolType } from "~/config/data/ccip/index.ts"
 import { areAllLanesPaused } from "~/config/data/ccip/utils.ts"
 import { ChainType, ExplorerInfo } from "~/config/types.ts"
@@ -86,6 +86,7 @@ function TokenChainsTable({ networks, token, lanes, environment }: TableProps) {
                         type="button"
                         className={`ccip-table__network-name ${allLanesPaused ? "ccip-table__network-name--paused" : ""}`}
                         onClick={() => {
+                          drawerWidthStore.set(DrawerWidth.Wide)
                           drawerContentStore.set(() => (
                             <TokenDrawer
                               token={token}

--- a/src/pages/certification.astro
+++ b/src/pages/certification.astro
@@ -212,7 +212,6 @@ const formattedContentTitle = `Courses | Chainlink Certifications`
                   src="/images/certification/Imagedevhubresources.png"
                   loading="lazy"
                   sizes="(max-width: 560px) 100vw, 560px"
-                  "
                   alt=""
                   class="cover-image"
                 />


### PR DESCRIPTION
- Add sublabels (Tokens) and (Tokens/sec) to rate limit columns in TokenDrawer lanes table
- Scope table column width rules to drawer container to prevent breaking TokenChainsTable layout
- Remove padding-left from general th elements and scope to drawer lanes table only
- Add ccip-table__verifier-name-header class to prevent padding on Verifiers tab table
- Set drawer width to Wide when opening token details from token cards and chains table

<img width="1599" height="874" alt="image" src="https://github.com/user-attachments/assets/43feb9aa-84ec-44f5-9b8e-e2650f42230a" />
