### PR TITLE
Enhance TokenDrawer: Add tooltips for FTF rate limit capacity and refill rate

### DIFF
--- a/src/components/CCIP/Drawer/TokenDrawer.tsx
+++ b/src/components/CCIP/Drawer/TokenDrawer.tsx
@@ -324,11 +324,39 @@ function TokenDrawer({
                     <span className="ccip-table__header-sublabel">(Tokens/sec)</span>
                   </th>
                   <th>
-                    <div>FTF Rate limit capacity</div>
+                    <div>
+                      FTF Rate limit capacity
+                      <Tooltip
+                        label=""
+                        tip="Maximum amount per transaction for fast transfers"
+                        labelStyle={{
+                          marginRight: "5px",
+                        }}
+                        style={{
+                          display: "inline-block",
+                          verticalAlign: "middle",
+                          marginBottom: "2px",
+                        }}
+                      />
+                    </div>
                     <span className="ccip-table__header-sublabel">(Tokens)</span>
                   </th>
                   <th>
-                    <div>FTF Rate limit refill rate</div>
+                    <div>
+                      FTF Rate limit refill rate
+                      <Tooltip
+                        label=""
+                        tip="Rate at which available capacity is replenished for fast transfers"
+                        labelStyle={{
+                          marginRight: "5px",
+                        }}
+                        style={{
+                          display: "inline-block",
+                          verticalAlign: "middle",
+                          marginBottom: "2px",
+                        }}
+                      />
+                    </div>
                     <span className="ccip-table__header-sublabel">(Tokens/sec)</span>
                   </th>
                   <th>Verifiers</th>


### PR DESCRIPTION

Added a tool tip for FTF Rate Limit capacity and refill rate similar to the standard ones
<img width="1462" height="870" alt="image" src="https://github.com/user-attachments/assets/def1715e-ed6b-47dd-a6f5-86ce40d75a34" />
