### PR TITLE
feat: add feature flag to toggle Verifiers accordion in TokenDrawer

### DIFF
--- a/src/components/CCIP/Drawer/NetworkLaneRow.tsx
+++ b/src/components/CCIP/Drawer/NetworkLaneRow.tsx
@@ -1,3 +1,12 @@
+// AI AGENT NOTE: This component is the accordion variant of the network lane row (used when SHOW_VERIFIERS_ACCORDION = true).
+// Any UI changes to the row layout (columns, styling, network name cell, rate limit cells, etc.) must also be
+// applied to NetworkLaneRowNoVerifiers.tsx to keep both variants in sync.
+//
+// When the Verifiers sub-table feature is fully released, we will:
+//   1. Remove the SHOW_VERIFIERS_ACCORDION feature flag from TokenDrawer.tsx
+//   2. Delete NetworkLaneRowNoVerifiers.tsx
+//   3. Use this component (NetworkLaneRow) unconditionally
+
 import { Fragment } from "react"
 import type { RateLimiterConfig } from "~/lib/ccip/types/index.ts"
 import type { Verifier } from "~/config/data/ccip/index.ts"
@@ -32,68 +41,72 @@ export function NetworkLaneRow({
 }: NetworkLaneRowProps) {
   return (
     <Fragment>
-    <tr
-      className={`ccip-table__accordion-row ${tokenPaused ? "ccip-table__row--paused" : ""} ${isExpanded ? "ccip-table__accordion-row--expanded" : ""}`}
-      onClick={onToggle}
-      role="button"
-      tabIndex={0}
-      aria-expanded={isExpanded}
-      aria-label={`${isExpanded ? "Hide" : "Show"} verifiers for ${networkDetails.name}`}
-      onKeyDown={(e) => {
-        if (e.key === "Enter" || e.key === " ") {
-          e.preventDefault()
-          onToggle()
-        }
-      }}
-    >
-      <td>
-        <div className={`ccip-table__network-name ${tokenPaused ? "ccip-table__network-name--paused" : ""}`}>
-          <img src={networkDetails.logo} alt={`${networkDetails.name} blockchain logo`} className="ccip-table__logo" />
-          {networkDetails.name}
-          {tokenPaused && (
-            <span className="ccip-table__paused-badge" title="Transfers are currently paused">
-              ⏸️
-            </span>
-          )}
-        </div>
-      </td>
-      <td>{mechanism}</td>
-      <td>
-        <RateLimitCell isLoading={isLoadingRateLimits} rateLimit={allLimits.standard} type="capacity" />
-      </td>
-      <td>
-        <RateLimitCell isLoading={isLoadingRateLimits} rateLimit={allLimits.standard} type="rate" />
-      </td>
-      <td>
-        <RateLimitCell isLoading={isLoadingRateLimits} rateLimit={allLimits.ftf} type="capacity" />
-      </td>
-      <td>
-        <RateLimitCell isLoading={isLoadingRateLimits} rateLimit={allLimits.ftf} type="rate" />
-      </td>
-      <td>
-        <div className="ccip-table__verifier-toggle">
-          <svg
-            className={`ccip-table__expand-icon ${isExpanded ? "ccip-table__expand-icon--expanded" : ""}`}
-            width="16"
-            height="16"
-            viewBox="0 0 16 16"
-            fill="none"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              d="M4 6L8 10L12 6"
-              stroke="currentColor"
-              strokeWidth="2"
-              strokeLinecap="round"
-              strokeLinejoin="round"
+      <tr
+        className={`ccip-table__accordion-row ${tokenPaused ? "ccip-table__row--paused" : ""} ${isExpanded ? "ccip-table__accordion-row--expanded" : ""}`}
+        onClick={onToggle}
+        role="button"
+        tabIndex={0}
+        aria-expanded={isExpanded}
+        aria-label={`${isExpanded ? "Hide" : "Show"} verifiers for ${networkDetails.name}`}
+        onKeyDown={(e) => {
+          if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault()
+            onToggle()
+          }
+        }}
+      >
+        <td>
+          <div className={`ccip-table__network-name ${tokenPaused ? "ccip-table__network-name--paused" : ""}`}>
+            <img
+              src={networkDetails.logo}
+              alt={`${networkDetails.name} blockchain logo`}
+              className="ccip-table__logo"
             />
-          </svg>
-        </div>
-      </td>
-    </tr>
-    {isExpanded && (
-      <VerifiersAccordionRow destinationVerifiers={destinationVerifiers} explorer={explorer} chainType={chainType} />
-    )}
+            {networkDetails.name}
+            {tokenPaused && (
+              <span className="ccip-table__paused-badge" title="Transfers are currently paused">
+                ⏸️
+              </span>
+            )}
+          </div>
+        </td>
+        <td>{mechanism}</td>
+        <td>
+          <RateLimitCell isLoading={isLoadingRateLimits} rateLimit={allLimits.standard} type="capacity" />
+        </td>
+        <td>
+          <RateLimitCell isLoading={isLoadingRateLimits} rateLimit={allLimits.standard} type="rate" />
+        </td>
+        <td>
+          <RateLimitCell isLoading={isLoadingRateLimits} rateLimit={allLimits.ftf} type="capacity" />
+        </td>
+        <td>
+          <RateLimitCell isLoading={isLoadingRateLimits} rateLimit={allLimits.ftf} type="rate" />
+        </td>
+        <td>
+          <div className="ccip-table__verifier-toggle">
+            <svg
+              className={`ccip-table__expand-icon ${isExpanded ? "ccip-table__expand-icon--expanded" : ""}`}
+              width="16"
+              height="16"
+              viewBox="0 0 16 16"
+              fill="none"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M4 6L8 10L12 6"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
+            </svg>
+          </div>
+        </td>
+      </tr>
+      {isExpanded && (
+        <VerifiersAccordionRow destinationVerifiers={destinationVerifiers} explorer={explorer} chainType={chainType} />
+      )}
     </Fragment>
   )
 }

--- a/src/components/CCIP/Drawer/NetworkLaneRow.tsx
+++ b/src/components/CCIP/Drawer/NetworkLaneRow.tsx
@@ -1,0 +1,92 @@
+import type { RateLimiterConfig } from "~/lib/ccip/types/index.ts"
+import { RateLimitCell } from "~/components/CCIP/RateLimitCell.tsx"
+
+export interface NetworkLaneRowProps {
+  networkDetails: { name: string; logo: string }
+  tokenPaused: boolean
+  isExpanded: boolean
+  showAccordion: boolean
+  onToggle: () => void
+  mechanism: string
+  allLimits: { standard: RateLimiterConfig | null; ftf: RateLimiterConfig | null }
+  isLoadingRateLimits: boolean
+}
+
+export function NetworkLaneRow({
+  networkDetails,
+  tokenPaused,
+  isExpanded,
+  showAccordion,
+  onToggle,
+  mechanism,
+  allLimits,
+  isLoadingRateLimits,
+}: NetworkLaneRowProps) {
+  return (
+    <tr
+      className={`${showAccordion ? "ccip-table__accordion-row" : ""} ${tokenPaused ? "ccip-table__row--paused" : ""} ${isExpanded ? "ccip-table__accordion-row--expanded" : ""}`}
+      onClick={showAccordion ? onToggle : undefined}
+      role={showAccordion ? "button" : undefined}
+      tabIndex={showAccordion ? 0 : undefined}
+      aria-expanded={showAccordion ? isExpanded : undefined}
+      aria-label={showAccordion ? `${isExpanded ? "Hide" : "Show"} verifiers for ${networkDetails.name}` : undefined}
+      onKeyDown={
+        showAccordion
+          ? (e) => {
+              if (e.key === "Enter" || e.key === " ") {
+                e.preventDefault()
+                onToggle()
+              }
+            }
+          : undefined
+      }
+    >
+      <td>
+        <div className={`ccip-table__network-name ${tokenPaused ? "ccip-table__network-name--paused" : ""}`}>
+          <img src={networkDetails.logo} alt={`${networkDetails.name} blockchain logo`} className="ccip-table__logo" />
+          {networkDetails.name}
+          {tokenPaused && (
+            <span className="ccip-table__paused-badge" title="Transfers are currently paused">
+              ⏸️
+            </span>
+          )}
+        </div>
+      </td>
+      <td>{mechanism}</td>
+      <td>
+        <RateLimitCell isLoading={isLoadingRateLimits} rateLimit={allLimits.standard} type="capacity" />
+      </td>
+      <td>
+        <RateLimitCell isLoading={isLoadingRateLimits} rateLimit={allLimits.standard} type="rate" />
+      </td>
+      <td>
+        <RateLimitCell isLoading={isLoadingRateLimits} rateLimit={allLimits.ftf} type="capacity" />
+      </td>
+      <td>
+        <RateLimitCell isLoading={isLoadingRateLimits} rateLimit={allLimits.ftf} type="rate" />
+      </td>
+      {showAccordion && (
+        <td>
+          <div className="ccip-table__verifier-toggle">
+            <svg
+              className={`ccip-table__expand-icon ${isExpanded ? "ccip-table__expand-icon--expanded" : ""}`}
+              width="16"
+              height="16"
+              viewBox="0 0 16 16"
+              fill="none"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M4 6L8 10L12 6"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
+            </svg>
+          </div>
+        </td>
+      )}
+    </tr>
+  )
+}

--- a/src/components/CCIP/Drawer/NetworkLaneRow.tsx
+++ b/src/components/CCIP/Drawer/NetworkLaneRow.tsx
@@ -1,45 +1,50 @@
+import { Fragment } from "react"
 import type { RateLimiterConfig } from "~/lib/ccip/types/index.ts"
+import type { Verifier } from "~/config/data/ccip/index.ts"
+import type { ChainType, ExplorerInfo } from "~/config/index.ts"
 import { RateLimitCell } from "~/components/CCIP/RateLimitCell.tsx"
+import { VerifiersAccordionRow } from "./VerifiersAccordionRow.tsx"
 
 export interface NetworkLaneRowProps {
   networkDetails: { name: string; logo: string }
   tokenPaused: boolean
   isExpanded: boolean
-  showAccordion: boolean
   onToggle: () => void
   mechanism: string
   allLimits: { standard: RateLimiterConfig | null; ftf: RateLimiterConfig | null }
   isLoadingRateLimits: boolean
+  destinationVerifiers: Verifier[]
+  explorer: ExplorerInfo
+  chainType: ChainType
 }
 
 export function NetworkLaneRow({
   networkDetails,
   tokenPaused,
   isExpanded,
-  showAccordion,
   onToggle,
   mechanism,
   allLimits,
   isLoadingRateLimits,
+  destinationVerifiers,
+  explorer,
+  chainType,
 }: NetworkLaneRowProps) {
   return (
+    <Fragment>
     <tr
-      className={`${showAccordion ? "ccip-table__accordion-row" : ""} ${tokenPaused ? "ccip-table__row--paused" : ""} ${isExpanded ? "ccip-table__accordion-row--expanded" : ""}`}
-      onClick={showAccordion ? onToggle : undefined}
-      role={showAccordion ? "button" : undefined}
-      tabIndex={showAccordion ? 0 : undefined}
-      aria-expanded={showAccordion ? isExpanded : undefined}
-      aria-label={showAccordion ? `${isExpanded ? "Hide" : "Show"} verifiers for ${networkDetails.name}` : undefined}
-      onKeyDown={
-        showAccordion
-          ? (e) => {
-              if (e.key === "Enter" || e.key === " ") {
-                e.preventDefault()
-                onToggle()
-              }
-            }
-          : undefined
-      }
+      className={`ccip-table__accordion-row ${tokenPaused ? "ccip-table__row--paused" : ""} ${isExpanded ? "ccip-table__accordion-row--expanded" : ""}`}
+      onClick={onToggle}
+      role="button"
+      tabIndex={0}
+      aria-expanded={isExpanded}
+      aria-label={`${isExpanded ? "Hide" : "Show"} verifiers for ${networkDetails.name}`}
+      onKeyDown={(e) => {
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault()
+          onToggle()
+        }
+      }}
     >
       <td>
         <div className={`ccip-table__network-name ${tokenPaused ? "ccip-table__network-name--paused" : ""}`}>
@@ -65,28 +70,30 @@ export function NetworkLaneRow({
       <td>
         <RateLimitCell isLoading={isLoadingRateLimits} rateLimit={allLimits.ftf} type="rate" />
       </td>
-      {showAccordion && (
-        <td>
-          <div className="ccip-table__verifier-toggle">
-            <svg
-              className={`ccip-table__expand-icon ${isExpanded ? "ccip-table__expand-icon--expanded" : ""}`}
-              width="16"
-              height="16"
-              viewBox="0 0 16 16"
-              fill="none"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M4 6L8 10L12 6"
-                stroke="currentColor"
-                strokeWidth="2"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-              />
-            </svg>
-          </div>
-        </td>
-      )}
+      <td>
+        <div className="ccip-table__verifier-toggle">
+          <svg
+            className={`ccip-table__expand-icon ${isExpanded ? "ccip-table__expand-icon--expanded" : ""}`}
+            width="16"
+            height="16"
+            viewBox="0 0 16 16"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M4 6L8 10L12 6"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+          </svg>
+        </div>
+      </td>
     </tr>
+    {isExpanded && (
+      <VerifiersAccordionRow destinationVerifiers={destinationVerifiers} explorer={explorer} chainType={chainType} />
+    )}
+    </Fragment>
   )
 }

--- a/src/components/CCIP/Drawer/NetworkLaneRowNoVerifiers.tsx
+++ b/src/components/CCIP/Drawer/NetworkLaneRowNoVerifiers.tsx
@@ -1,3 +1,10 @@
+// AI AGENT NOTE: This is a temporary component used while SHOW_VERIFIERS_ACCORDION = false in TokenDrawer.tsx.
+// It mirrors the row layout of NetworkLaneRow.tsx without the accordion/verifiers functionality.
+// Any UI changes to the row layout (columns, styling, network name cell, rate limit cells, etc.) must also be
+// applied to NetworkLaneRow.tsx to keep both variants in sync.
+//
+// When the Verifiers sub-table feature is fully released, this file should be deleted entirely.
+
 import type { RateLimiterConfig } from "~/lib/ccip/types/index.ts"
 import { RateLimitCell } from "~/components/CCIP/RateLimitCell.tsx"
 

--- a/src/components/CCIP/Drawer/NetworkLaneRowNoVerifiers.tsx
+++ b/src/components/CCIP/Drawer/NetworkLaneRowNoVerifiers.tsx
@@ -1,0 +1,47 @@
+import type { RateLimiterConfig } from "~/lib/ccip/types/index.ts"
+import { RateLimitCell } from "~/components/CCIP/RateLimitCell.tsx"
+
+export interface NetworkLaneRowNoVerifiersProps {
+  networkDetails: { name: string; logo: string }
+  tokenPaused: boolean
+  mechanism: string
+  allLimits: { standard: RateLimiterConfig | null; ftf: RateLimiterConfig | null }
+  isLoadingRateLimits: boolean
+}
+
+export function NetworkLaneRowNoVerifiers({
+  networkDetails,
+  tokenPaused,
+  mechanism,
+  allLimits,
+  isLoadingRateLimits,
+}: NetworkLaneRowNoVerifiersProps) {
+  return (
+    <tr className={tokenPaused ? "ccip-table__row--paused" : ""}>
+      <td>
+        <div className={`ccip-table__network-name ${tokenPaused ? "ccip-table__network-name--paused" : ""}`}>
+          <img src={networkDetails.logo} alt={`${networkDetails.name} blockchain logo`} className="ccip-table__logo" />
+          {networkDetails.name}
+          {tokenPaused && (
+            <span className="ccip-table__paused-badge" title="Transfers are currently paused">
+              ⏸️
+            </span>
+          )}
+        </div>
+      </td>
+      <td>{mechanism}</td>
+      <td>
+        <RateLimitCell isLoading={isLoadingRateLimits} rateLimit={allLimits.standard} type="capacity" />
+      </td>
+      <td>
+        <RateLimitCell isLoading={isLoadingRateLimits} rateLimit={allLimits.standard} type="rate" />
+      </td>
+      <td>
+        <RateLimitCell isLoading={isLoadingRateLimits} rateLimit={allLimits.ftf} type="capacity" />
+      </td>
+      <td>
+        <RateLimitCell isLoading={isLoadingRateLimits} rateLimit={allLimits.ftf} type="rate" />
+      </td>
+    </tr>
+  )
+}

--- a/src/components/CCIP/Drawer/TokenDrawer.tsx
+++ b/src/components/CCIP/Drawer/TokenDrawer.tsx
@@ -24,6 +24,11 @@ import { RateLimitCell } from "~/components/CCIP/RateLimitCell.tsx"
 import { realtimeDataService } from "~/lib/ccip/services/realtime-data-instance.ts"
 import { Typography } from "@chainlink/blocks"
 
+// ─── Feature flag ────────────────────────────────────────────────────────────
+// Set to `true` once the backend is ready to re-enable the Verifiers accordion.
+const SHOW_VERIFIERS_ACCORDION = false
+// ─────────────────────────────────────────────────────────────────────────────
+
 enum TokenTab {
   Outbound = "outbound",
   Inbound = "inbound",
@@ -248,7 +253,7 @@ function TokenDrawer({
                   <div>FTF Rate limit refill rate</div>
                   <span className="ccip-table__header-sublabel">(Tokens/sec)</span>
                 </th>
-                <th>Verifiers</th>
+                {SHOW_VERIFIERS_ACCORDION && <th>Verifiers</th>}
               </tr>
             </thead>
             <tbody>
@@ -275,31 +280,41 @@ function TokenDrawer({
                   // Token is paused if standard rate limit capacity is 0
                   const tokenPaused = allLimits.standard?.capacity === "0"
 
-                  // Get verifiers for the destination network
-                  const destinationVerifiers = getVerifiersByNetwork({
-                    networkId: destinationChain,
-                    environment,
-                    version: Version.V1_2_0,
-                  })
+                  // Get verifiers for the destination network (safe fallback to empty array)
+                  const destinationVerifiers = SHOW_VERIFIERS_ACCORDION
+                    ? (getVerifiersByNetwork({
+                        networkId: destinationChain,
+                        environment,
+                        version: Version.V1_2_0,
+                      }) ?? [])
+                    : []
 
-                  const isExpanded = expandedRows.has(networkDetails.name)
+                  const isExpanded = SHOW_VERIFIERS_ACCORDION && expandedRows.has(networkDetails.name)
 
                   return (
                     <>
                       <tr
                         key={networkDetails.name}
-                        className={`ccip-table__accordion-row ${tokenPaused ? "ccip-table__row--paused" : ""} ${isExpanded ? "ccip-table__accordion-row--expanded" : ""}`}
-                        onClick={() => toggleRowExpansion(networkDetails.name)}
-                        role="button"
-                        tabIndex={0}
-                        aria-expanded={isExpanded}
-                        aria-label={`${isExpanded ? "Hide" : "Show"} verifiers for ${networkDetails?.name}`}
-                        onKeyDown={(e) => {
-                          if (e.key === "Enter" || e.key === " ") {
-                            e.preventDefault()
-                            toggleRowExpansion(networkDetails.name)
-                          }
-                        }}
+                        className={`${SHOW_VERIFIERS_ACCORDION ? "ccip-table__accordion-row" : ""} ${tokenPaused ? "ccip-table__row--paused" : ""} ${isExpanded ? "ccip-table__accordion-row--expanded" : ""}`}
+                        onClick={SHOW_VERIFIERS_ACCORDION ? () => toggleRowExpansion(networkDetails.name) : undefined}
+                        role={SHOW_VERIFIERS_ACCORDION ? "button" : undefined}
+                        tabIndex={SHOW_VERIFIERS_ACCORDION ? 0 : undefined}
+                        aria-expanded={SHOW_VERIFIERS_ACCORDION ? isExpanded : undefined}
+                        aria-label={
+                          SHOW_VERIFIERS_ACCORDION
+                            ? `${isExpanded ? "Hide" : "Show"} verifiers for ${networkDetails?.name}`
+                            : undefined
+                        }
+                        onKeyDown={
+                          SHOW_VERIFIERS_ACCORDION
+                            ? (e) => {
+                                if (e.key === "Enter" || e.key === " ") {
+                                  e.preventDefault()
+                                  toggleRowExpansion(networkDetails.name)
+                                }
+                              }
+                            : undefined
+                        }
                       >
                         <td>
                           <div
@@ -339,28 +354,30 @@ function TokenDrawer({
                         <td>
                           <RateLimitCell isLoading={isLoadingRateLimits} rateLimit={allLimits.ftf} type="rate" />
                         </td>
-                        <td>
-                          <div className="ccip-table__verifier-toggle">
-                            <svg
-                              className={`ccip-table__expand-icon ${isExpanded ? "ccip-table__expand-icon--expanded" : ""}`}
-                              width="16"
-                              height="16"
-                              viewBox="0 0 16 16"
-                              fill="none"
-                              xmlns="http://www.w3.org/2000/svg"
-                            >
-                              <path
-                                d="M4 6L8 10L12 6"
-                                stroke="currentColor"
-                                strokeWidth="2"
-                                strokeLinecap="round"
-                                strokeLinejoin="round"
-                              />
-                            </svg>
-                          </div>
-                        </td>
+                        {SHOW_VERIFIERS_ACCORDION && (
+                          <td>
+                            <div className="ccip-table__verifier-toggle">
+                              <svg
+                                className={`ccip-table__expand-icon ${isExpanded ? "ccip-table__expand-icon--expanded" : ""}`}
+                                width="16"
+                                height="16"
+                                viewBox="0 0 16 16"
+                                fill="none"
+                                xmlns="http://www.w3.org/2000/svg"
+                              >
+                                <path
+                                  d="M4 6L8 10L12 6"
+                                  stroke="currentColor"
+                                  strokeWidth="2"
+                                  strokeLinecap="round"
+                                  strokeLinejoin="round"
+                                />
+                              </svg>
+                            </div>
+                          </td>
+                        )}
                       </tr>
-                      {isExpanded && (
+                      {SHOW_VERIFIERS_ACCORDION && isExpanded && (
                         <tr className="ccip-table__verifier-row">
                           <td colSpan={7} style={{ padding: 0 }}>
                             <div className="ccip-table__verifier-content">

--- a/src/components/CCIP/Drawer/TokenDrawer.tsx
+++ b/src/components/CCIP/Drawer/TokenDrawer.tsx
@@ -20,7 +20,7 @@ import { Tooltip } from "~/features/common/Tooltip/Tooltip.tsx"
 import { useMultiLaneRateLimits } from "~/hooks/useMultiLaneRateLimits.ts"
 import { realtimeDataService } from "~/lib/ccip/services/realtime-data-instance.ts"
 import { NetworkLaneRow } from "./NetworkLaneRow.tsx"
-import { VerifiersAccordionRow } from "./VerifiersAccordionRow.tsx"
+import { NetworkLaneRowNoVerifiers } from "./NetworkLaneRowNoVerifiers.tsx"
 
 // Feature flag: set to `true` once the backend is ready to re-enable the Verifiers accordion.
 const SHOW_VERIFIERS_ACCORDION = false
@@ -287,30 +287,33 @@ function TokenDrawer({
 
                   const isExpanded = SHOW_VERIFIERS_ACCORDION && expandedRows.has(networkDetails.name)
 
-                  return (
-                    <Fragment key={networkDetails.name}>
-                      <NetworkLaneRow
-                        networkDetails={networkDetails}
-                        tokenPaused={tokenPaused}
-                        isExpanded={isExpanded}
-                        showAccordion={SHOW_VERIFIERS_ACCORDION}
-                        onToggle={() => toggleRowExpansion(networkDetails.name)}
-                        mechanism={
-                          activeTab === TokenTab.Outbound
-                            ? determineTokenMechanism(network.tokenPoolType, destinationPoolType)
-                            : determineTokenMechanism(destinationPoolType, network.tokenPoolType)
-                        }
-                        allLimits={allLimits}
-                        isLoadingRateLimits={isLoadingRateLimits}
-                      />
-                      {SHOW_VERIFIERS_ACCORDION && isExpanded && (
-                        <VerifiersAccordionRow
-                          destinationVerifiers={destinationVerifiers}
-                          explorer={network.explorer}
-                          chainType={network.chainType}
-                        />
-                      )}
-                    </Fragment>
+                  const mechanism =
+                    activeTab === TokenTab.Outbound
+                      ? determineTokenMechanism(network.tokenPoolType, destinationPoolType)
+                      : determineTokenMechanism(destinationPoolType, network.tokenPoolType)
+
+                  return SHOW_VERIFIERS_ACCORDION ? (
+                    <NetworkLaneRow
+                      key={networkDetails.name}
+                      networkDetails={networkDetails}
+                      tokenPaused={tokenPaused}
+                      isExpanded={isExpanded}
+                      onToggle={() => toggleRowExpansion(networkDetails.name)}
+                      mechanism={mechanism}
+                      allLimits={allLimits}
+                      isLoadingRateLimits={isLoadingRateLimits}
+                      destinationVerifiers={destinationVerifiers}
+                      explorer={network.explorer}
+                      chainType={network.chainType}
+                    />
+                  ) : (
+                    <NetworkLaneRowNoVerifiers
+                      networkDetails={networkDetails}
+                      tokenPaused={tokenPaused}
+                      mechanism={mechanism}
+                      allLimits={allLimits}
+                      isLoadingRateLimits={isLoadingRateLimits}
+                    />
                   )
                 })}
             </tbody>

--- a/src/components/CCIP/Drawer/TokenDrawer.tsx
+++ b/src/components/CCIP/Drawer/TokenDrawer.tsx
@@ -14,18 +14,16 @@ import {
 } from "~/config/data/ccip/index.ts"
 import { useState, useMemo, Fragment } from "react"
 import { ChainType, ExplorerInfo, SupportedChain } from "~/config/index.ts"
-import { getExplorerAddressUrl } from "~/features/utils/index.ts"
-import Address from "~/components/AddressReact.tsx"
 import TableSearchInput from "../Tables/TableSearchInput.tsx"
 import Tabs from "../Tables/Tabs.tsx"
 import { Tooltip } from "~/features/common/Tooltip/Tooltip.tsx"
 import { useMultiLaneRateLimits } from "~/hooks/useMultiLaneRateLimits.ts"
-import { RateLimitCell } from "~/components/CCIP/RateLimitCell.tsx"
 import { realtimeDataService } from "~/lib/ccip/services/realtime-data-instance.ts"
-import { Typography } from "@chainlink/blocks"
+import { NetworkLaneRow } from "./NetworkLaneRow.tsx"
+import { VerifiersAccordionRow } from "./VerifiersAccordionRow.tsx"
 
 // Feature flag: set to `true` once the backend is ready to re-enable the Verifiers accordion.
-const SHOW_VERIFIERS_ACCORDION = true
+const SHOW_VERIFIERS_ACCORDION = false
 
 enum TokenTab {
   Outbound = "outbound",
@@ -291,161 +289,26 @@ function TokenDrawer({
 
                   return (
                     <Fragment key={networkDetails.name}>
-                      <tr
-                        className={`${SHOW_VERIFIERS_ACCORDION ? "ccip-table__accordion-row" : ""} ${tokenPaused ? "ccip-table__row--paused" : ""} ${isExpanded ? "ccip-table__accordion-row--expanded" : ""}`}
-                        onClick={SHOW_VERIFIERS_ACCORDION ? () => toggleRowExpansion(networkDetails.name) : undefined}
-                        role={SHOW_VERIFIERS_ACCORDION ? "button" : undefined}
-                        tabIndex={SHOW_VERIFIERS_ACCORDION ? 0 : undefined}
-                        aria-expanded={SHOW_VERIFIERS_ACCORDION ? isExpanded : undefined}
-                        aria-label={
-                          SHOW_VERIFIERS_ACCORDION
-                            ? `${isExpanded ? "Hide" : "Show"} verifiers for ${networkDetails?.name}`
-                            : undefined
-                        }
-                        onKeyDown={
-                          SHOW_VERIFIERS_ACCORDION
-                            ? (e) => {
-                                if (e.key === "Enter" || e.key === " ") {
-                                  e.preventDefault()
-                                  toggleRowExpansion(networkDetails.name)
-                                }
-                              }
-                            : undefined
-                        }
-                      >
-                        <td>
-                          <div
-                            className={`ccip-table__network-name ${tokenPaused ? "ccip-table__network-name--paused" : ""}`}
-                          >
-                            <img
-                              src={networkDetails?.logo}
-                              alt={`${networkDetails?.name} blockchain logo`}
-                              className="ccip-table__logo"
-                            />
-                            {networkDetails?.name}
-                            {tokenPaused && (
-                              <span className="ccip-table__paused-badge" title="Transfers are currently paused">
-                                ⏸️
-                              </span>
-                            )}
-                          </div>
-                        </td>
-                        <td>
-                          {activeTab === TokenTab.Outbound
+                      <NetworkLaneRow
+                        networkDetails={networkDetails}
+                        tokenPaused={tokenPaused}
+                        isExpanded={isExpanded}
+                        showAccordion={SHOW_VERIFIERS_ACCORDION}
+                        onToggle={() => toggleRowExpansion(networkDetails.name)}
+                        mechanism={
+                          activeTab === TokenTab.Outbound
                             ? determineTokenMechanism(network.tokenPoolType, destinationPoolType)
-                            : determineTokenMechanism(destinationPoolType, network.tokenPoolType)}
-                        </td>
-                        <td>
-                          <RateLimitCell
-                            isLoading={isLoadingRateLimits}
-                            rateLimit={allLimits.standard}
-                            type="capacity"
-                          />
-                        </td>
-                        <td>
-                          <RateLimitCell isLoading={isLoadingRateLimits} rateLimit={allLimits.standard} type="rate" />
-                        </td>
-                        <td>
-                          <RateLimitCell isLoading={isLoadingRateLimits} rateLimit={allLimits.ftf} type="capacity" />
-                        </td>
-                        <td>
-                          <RateLimitCell isLoading={isLoadingRateLimits} rateLimit={allLimits.ftf} type="rate" />
-                        </td>
-                        {SHOW_VERIFIERS_ACCORDION && (
-                          <td>
-                            <div className="ccip-table__verifier-toggle">
-                              <svg
-                                className={`ccip-table__expand-icon ${isExpanded ? "ccip-table__expand-icon--expanded" : ""}`}
-                                width="16"
-                                height="16"
-                                viewBox="0 0 16 16"
-                                fill="none"
-                                xmlns="http://www.w3.org/2000/svg"
-                              >
-                                <path
-                                  d="M4 6L8 10L12 6"
-                                  stroke="currentColor"
-                                  strokeWidth="2"
-                                  strokeLinecap="round"
-                                  strokeLinejoin="round"
-                                />
-                              </svg>
-                            </div>
-                          </td>
-                        )}
-                      </tr>
+                            : determineTokenMechanism(destinationPoolType, network.tokenPoolType)
+                        }
+                        allLimits={allLimits}
+                        isLoadingRateLimits={isLoadingRateLimits}
+                      />
                       {SHOW_VERIFIERS_ACCORDION && isExpanded && (
-                        <tr className="ccip-table__verifier-row">
-                          <td colSpan={7} style={{ padding: 0 }}>
-                            <div className="ccip-table__verifier-content">
-                              {destinationVerifiers.length === 0 ? (
-                                <div
-                                  style={{
-                                    textAlign: "center",
-                                    padding: "20px",
-                                    display: "flex",
-                                    alignItems: "center",
-                                    justifyContent: "center",
-                                    minHeight: "60px",
-                                  }}
-                                >
-                                  <Typography variant="body">No verifiers found for this network.</Typography>
-                                </div>
-                              ) : (
-                                <table className="ccip-table ccip-table--verifiers">
-                                  <thead>
-                                    <tr>
-                                      <th>Verifier</th>
-                                      <th>Source verifier address</th>
-                                      <th>Destination verifier address</th>
-                                      <th>Threshold amount</th>
-                                    </tr>
-                                  </thead>
-                                  <tbody>
-                                    {destinationVerifiers.map((verifier) => (
-                                      <tr key={verifier.address}>
-                                        <td>
-                                          <div style={{ display: "flex", alignItems: "center", gap: "8px" }}>
-                                            <img
-                                              src={verifier.logo}
-                                              alt={`${verifier.name} logo`}
-                                              className="ccip-table__logo"
-                                              style={{ width: "24px", height: "24px" }}
-                                            />
-                                            <Typography variant="body">{verifier.name}</Typography>
-                                          </div>
-                                        </td>
-                                        <td>
-                                          <Address
-                                            contractUrl={getExplorerAddressUrl(
-                                              network.explorer,
-                                              network.chainType
-                                            )(verifier.address)}
-                                            address={verifier.address}
-                                            endLength={4}
-                                          />
-                                        </td>
-                                        <td>
-                                          <Address
-                                            contractUrl={getExplorerAddressUrl(
-                                              network.explorer,
-                                              network.chainType
-                                            )(verifier.address)}
-                                            address={verifier.address}
-                                            endLength={4}
-                                          />
-                                        </td>
-                                        <td>
-                                          <Typography variant="body">150,000</Typography>
-                                        </td>
-                                      </tr>
-                                    ))}
-                                  </tbody>
-                                </table>
-                              )}
-                            </div>
-                          </td>
-                        </tr>
+                        <VerifiersAccordionRow
+                          destinationVerifiers={destinationVerifiers}
+                          explorer={network.explorer}
+                          chainType={network.chainType}
+                        />
                       )}
                     </Fragment>
                   )

--- a/src/components/CCIP/Drawer/TokenDrawer.tsx
+++ b/src/components/CCIP/Drawer/TokenDrawer.tsx
@@ -12,7 +12,7 @@ import {
   LaneConfig,
   getVerifiersByNetwork,
 } from "~/config/data/ccip/index.ts"
-import { useState, useMemo } from "react"
+import { useState, useMemo, Fragment } from "react"
 import { ChainType, ExplorerInfo, SupportedChain } from "~/config/index.ts"
 import { getExplorerAddressUrl } from "~/features/utils/index.ts"
 import Address from "~/components/AddressReact.tsx"
@@ -24,10 +24,8 @@ import { RateLimitCell } from "~/components/CCIP/RateLimitCell.tsx"
 import { realtimeDataService } from "~/lib/ccip/services/realtime-data-instance.ts"
 import { Typography } from "@chainlink/blocks"
 
-// ─── Feature flag ────────────────────────────────────────────────────────────
-// Set to `true` once the backend is ready to re-enable the Verifiers accordion.
-const SHOW_VERIFIERS_ACCORDION = false
-// ─────────────────────────────────────────────────────────────────────────────
+// Feature flag: set to `true` once the backend is ready to re-enable the Verifiers accordion.
+const SHOW_VERIFIERS_ACCORDION = true
 
 enum TokenTab {
   Outbound = "outbound",
@@ -292,9 +290,8 @@ function TokenDrawer({
                   const isExpanded = SHOW_VERIFIERS_ACCORDION && expandedRows.has(networkDetails.name)
 
                   return (
-                    <>
+                    <Fragment key={networkDetails.name}>
                       <tr
-                        key={networkDetails.name}
                         className={`${SHOW_VERIFIERS_ACCORDION ? "ccip-table__accordion-row" : ""} ${tokenPaused ? "ccip-table__row--paused" : ""} ${isExpanded ? "ccip-table__accordion-row--expanded" : ""}`}
                         onClick={SHOW_VERIFIERS_ACCORDION ? () => toggleRowExpansion(networkDetails.name) : undefined}
                         role={SHOW_VERIFIERS_ACCORDION ? "button" : undefined}
@@ -450,7 +447,7 @@ function TokenDrawer({
                           </td>
                         </tr>
                       )}
-                    </>
+                    </Fragment>
                   )
                 })}
             </tbody>

--- a/src/components/CCIP/Drawer/TokenDrawer.tsx
+++ b/src/components/CCIP/Drawer/TokenDrawer.tsx
@@ -278,11 +278,11 @@ function TokenDrawer({
 
                   // Get verifiers for the destination network (safe fallback to empty array)
                   const destinationVerifiers = SHOW_VERIFIERS_ACCORDION
-                    ? (getVerifiersByNetwork({
+                    ? getVerifiersByNetwork({
                         networkId: destinationChain,
                         environment,
                         version: Version.V1_2_0,
-                      }) ?? [])
+                      })
                     : []
 
                   const isExpanded = SHOW_VERIFIERS_ACCORDION && expandedRows.has(networkDetails.name)

--- a/src/components/CCIP/Drawer/VerifiersAccordionRow.tsx
+++ b/src/components/CCIP/Drawer/VerifiersAccordionRow.tsx
@@ -1,0 +1,81 @@
+import { Verifier } from "~/config/data/ccip/index.ts"
+import { ChainType, ExplorerInfo } from "~/config/index.ts"
+import { getExplorerAddressUrl } from "~/features/utils/index.ts"
+import Address from "~/components/AddressReact.tsx"
+import { Typography } from "@chainlink/blocks"
+
+export interface VerifiersAccordionRowProps {
+  destinationVerifiers: Verifier[]
+  explorer: ExplorerInfo
+  chainType: ChainType
+}
+
+export function VerifiersAccordionRow({ destinationVerifiers, explorer, chainType }: VerifiersAccordionRowProps) {
+  return (
+    <tr className="ccip-table__verifier-row">
+      <td colSpan={7} style={{ padding: 0 }}>
+        <div className="ccip-table__verifier-content">
+          {destinationVerifiers.length === 0 ? (
+            <div
+              style={{
+                textAlign: "center",
+                padding: "20px",
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+                minHeight: "60px",
+              }}
+            >
+              <Typography variant="body">No verifiers found for this network.</Typography>
+            </div>
+          ) : (
+            <table className="ccip-table ccip-table--verifiers">
+              <thead>
+                <tr>
+                  <th>Verifier</th>
+                  <th>Source verifier address</th>
+                  <th>Destination verifier address</th>
+                  <th>Threshold amount</th>
+                </tr>
+              </thead>
+              <tbody>
+                {destinationVerifiers.map((verifier) => (
+                  <tr key={verifier.address}>
+                    <td>
+                      <div style={{ display: "flex", alignItems: "center", gap: "8px" }}>
+                        <img
+                          src={verifier.logo}
+                          alt={`${verifier.name} logo`}
+                          className="ccip-table__logo"
+                          style={{ width: "24px", height: "24px" }}
+                        />
+                        <Typography variant="body">{verifier.name}</Typography>
+                      </div>
+                    </td>
+                    <td>
+                      <Address
+                        contractUrl={getExplorerAddressUrl(explorer, chainType)(verifier.address)}
+                        address={verifier.address}
+                        endLength={4}
+                      />
+                    </td>
+                    <td>
+                      <Address
+                        contractUrl={getExplorerAddressUrl(explorer, chainType)(verifier.address)}
+                        address={verifier.address}
+                        endLength={4}
+                      />
+                    </td>
+                    <td>
+                      <Typography variant="body">150,000</Typography>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
+        </div>
+      </td>
+    </tr>
+  )
+}


### PR DESCRIPTION
Add SHOW_VERIFIERS_ACCORDION boolean at the top of TokenDrawer.tsx to enable/disable the verifiers expanding section and chevron. Set to false until the backend is ready; flip to true to re-enable.

<img width="1911" height="867" alt="Screenshot 2026-03-23 at 3 37 13 PM" src="https://github.com/user-attachments/assets/8e28cffc-3513-45f8-9ae6-a46179c150d9" />

## Closing issues

<!-- Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->

closes #257 


