### PR TITLE
fix: use chain.logo instead of getNetworkIconUrl in NetworkGrid

### DIFF
--- a/src/components/CCIP/Landing/NetworkGrid.tsx
+++ b/src/components/CCIP/Landing/NetworkGrid.tsx
@@ -1,6 +1,5 @@
 import Card from "../Cards/Card.tsx"
 import Grid from "./Grid.tsx"
-import { getNetworkIconUrl } from "~/config/data/ccip/data.ts"
 interface NetworkGridProps {
   networks: {
     name: string
@@ -25,7 +24,7 @@ function NetworkGrid({ networks, environment }: NetworkGridProps) {
         return (
           <Card
             key={chain.chain}
-            logo={<img src={getNetworkIconUrl(chain.name)} alt="" loading="lazy" />}
+            logo={<img src={chain.logo} alt="" loading="lazy" />}
             title={chain.name}
             subtitle={subtitle}
             link={`/ccip/directory/${environment}/chain/${chain.chain}`}


### PR DESCRIPTION
Testnet chain display names (e.g. 'Ethereum Sepolia') were being normalized to CDN paths that don't exist (e.g. ethereum-sepolia.svg). Mainnet names (e.g. 'Ethereum') happened to match CDN filenames.

getAllNetworks already computes the correct logo via getChainIcon, so use chain.logo directly and remove the getNetworkIconUrl call.

<img width="1622" height="869" alt="Screenshot 2026-04-01 at 1 09 14 PM" src="https://github.com/user-attachments/assets/869df638-b45e-4b40-9231-6e14f7709abf" />
