### PR TITLE
feat: make full table rows clickable to open drawer

### DIFF
--- a/src/components/AddressReact.tsx
+++ b/src/components/AddressReact.tsx
@@ -16,14 +16,22 @@ const AddressComponent = ({ contractUrl, address, endLength, urlClass, urlId }: 
 
   if (!address) return null
 
-  const handleClick = (e) => {
+  const handleClick = (e: React.MouseEvent) => {
     e.preventDefault()
+    e.stopPropagation()
     if (address) navigator.clipboard.writeText(address)
   }
 
   return (
     <span className={`addressContainer ${urlClass || ""}`} id={urlId}>
-      <a title={address} className="addressLink" href={contractUrl} target="_blank" rel="noopener noreferrer">
+      <a
+        title={address}
+        className="addressLink"
+        href={contractUrl}
+        target="_blank"
+        rel="noopener noreferrer"
+        onClick={(e) => e.stopPropagation()}
+      >
         {endLength && address ? address.slice(0, endLength + 2) + "..." + address.slice(-endLength) : address}
       </a>
       <button

--- a/src/components/CCIP/Tables/ChainTable.tsx
+++ b/src/components/CCIP/Tables/ChainTable.tsx
@@ -117,40 +117,48 @@ function ChainTable({ lanes, explorer, sourceNetwork, environment }: TableProps)
               ?.filter((network) => network.name.toLowerCase().includes(search.toLowerCase()))
               .slice(0, seeMore ? lanes.length : BEFORE_SEE_MORE)
               .map((network, index) => (
-                <tr key={index}>
-                  <td>
-                    <button
-                      type="button"
-                      className="ccip-table__network-name"
-                      onClick={() => {
-                        const laneData = getLane({
-                          sourceChain: sourceNetwork.key as SupportedChain,
-                          destinationChain: network.key as SupportedChain,
-                          environment,
-                          version: Version.V1_2_0,
-                        })
+                <tr
+                  key={index}
+                  className="ccip-table__row--clickable"
+                  onClick={() => {
+                    const laneData = getLane({
+                      sourceChain: sourceNetwork.key as SupportedChain,
+                      destinationChain: network.key as SupportedChain,
+                      environment,
+                      version: Version.V1_2_0,
+                    })
 
-                        drawerWidthStore.set(DrawerWidth.Wide)
-                        drawerContentStore.set(() => (
-                          <LaneDrawer
-                            environment={environment}
-                            lane={laneData}
-                            sourceNetwork={sourceNetwork}
-                            destinationNetwork={{
-                              name: network?.name || "",
-                              logo: network?.logo || "",
-                              key: network.key,
-                            }}
-                            inOutbound={inOutbound}
-                            explorer={explorer}
-                          />
-                        ))
-                      }}
-                      aria-label={`View lane details for ${network.name}`}
-                    >
+                    drawerWidthStore.set(DrawerWidth.Wide)
+                    drawerContentStore.set(() => (
+                      <LaneDrawer
+                        environment={environment}
+                        lane={laneData}
+                        sourceNetwork={sourceNetwork}
+                        destinationNetwork={{
+                          name: network?.name || "",
+                          logo: network?.logo || "",
+                          key: network.key,
+                        }}
+                        inOutbound={inOutbound}
+                        explorer={explorer}
+                      />
+                    ))
+                  }}
+                  role="button"
+                  tabIndex={0}
+                  aria-label={`View lane details for ${network.name}`}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter" || e.key === " ") {
+                      e.preventDefault()
+                      e.currentTarget.click()
+                    }
+                  }}
+                >
+                  <td>
+                    <span className="ccip-table__network-name">
                       <img src={network.logo} alt={`${network.name} blockchain logo`} className="ccip-table__logo" />
                       {network.name}
-                    </button>
+                    </span>
                   </td>
                   <td
                     style={{ textAlign: "right" }}

--- a/src/components/CCIP/Tables/Table.css
+++ b/src/components/CCIP/Tables/Table.css
@@ -105,6 +105,10 @@
   background-color: var(--gray-50);
 }
 
+.ccip-table__row--clickable {
+  cursor: pointer;
+}
+
 .ccip-table thead th {
   /* Body/Body Semi S */
   font-family: "Inter";

--- a/src/components/CCIP/Tables/TokenChainsTable.tsx
+++ b/src/components/CCIP/Tables/TokenChainsTable.tsx
@@ -89,23 +89,33 @@ function TokenChainsTable({ networks, token, lanes, environment }: TableProps) {
                 const allLanesPaused = areAllLanesPaused(network.tokenDecimals, lanes[network.key] || {})
 
                 return (
-                  <tr key={index} className={allLanesPaused ? "ccip-table__row--paused" : ""}>
+                  <tr
+                    key={index}
+                    className={`ccip-table__row--clickable ${allLanesPaused ? "ccip-table__row--paused" : ""}`}
+                    onClick={() => {
+                      drawerWidthStore.set(DrawerWidth.Wide)
+                      drawerContentStore.set(() => (
+                        <TokenDrawer
+                          token={token}
+                          network={network}
+                          environment={environment}
+                          poolTypesByChain={poolTypesByChain}
+                        />
+                      ))
+                    }}
+                    role="button"
+                    tabIndex={0}
+                    aria-label={`View ${network.name} token details`}
+                    onKeyDown={(e) => {
+                      if (e.key === "Enter" || e.key === " ") {
+                        e.preventDefault()
+                        e.currentTarget.click()
+                      }
+                    }}
+                  >
                     <td>
-                      <button
-                        type="button"
+                      <span
                         className={`ccip-table__network-name ${allLanesPaused ? "ccip-table__network-name--paused" : ""}`}
-                        onClick={() => {
-                          drawerWidthStore.set(DrawerWidth.Wide)
-                          drawerContentStore.set(() => (
-                            <TokenDrawer
-                              token={token}
-                              network={network}
-                              environment={environment}
-                              poolTypesByChain={poolTypesByChain}
-                            />
-                          ))
-                        }}
-                        aria-label={`View ${network.name} token details`}
                       >
                         <span className="ccip-table__logoContainer">
                           <img
@@ -136,7 +146,7 @@ function TokenChainsTable({ networks, token, lanes, environment }: TableProps) {
                             ⏸️
                           </span>
                         )}
-                      </button>
+                      </span>
                     </td>
                     <td>{network.tokenName}</td>
                     <td>{network.tokenSymbol}</td>


### PR DESCRIPTION
## Closing issues

closes #293

## Description

Makes entire table rows clickable in the CCIP Directory to open the drawer, instead of only the chain/token name being clickable.

## Changes

- Move `onClick` handler from the name button to the `<tr>` element in `ChainTable` and `TokenChainsTable`
- Convert name `<button>` elements to `<span>` since the row itself is now the interactive element
- Add `stopPropagation` to address links and copy buttons in `AddressReact` to prevent row click when interacting with those elements
- Add `cursor: pointer` styling for clickable rows
- Preserve keyboard accessibility with `role="button"`, `tabIndex`, and `onKeyDown` handlers